### PR TITLE
ci: npm OIDC release workflow (ported from terra-react); fix malformed packageManager

### DIFF
--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -1,0 +1,48 @@
+name: Release package
+
+# Ported from tryterra/terra-react. Publishes react-native-terra-rt-react to
+# npm via npm "trusted publishing" (OIDC) — no stored token. Create a GitHub
+# Release to publish to `latest`, or workflow_dispatch (used by the
+# bump-terra-rt-react workflows in the native SDK repos).
+#
+# Requires a Trusted Publisher on npmjs.com: org tryterra, repo terra-rt-react,
+# workflow release_package.yml. The build runs explicitly (`yarn prepack`)
+# because publish uses --ignore-scripts and this package has no `prepare`
+# script.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch/tag to publish (blank = this ref)'
+        required: false
+        default: ''
+      dist-tag:
+        description: 'npm dist-tag'
+        required: false
+        default: 'latest'
+
+permissions:
+  id-token: write # mint the OIDC token npm exchanges for a short-lived publish credential
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org/'
+      - name: Ensure npm supports trusted publishing (>= 11.5.1)
+        run: npm install -g npm@latest
+      - name: Install
+        run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn prepack
+      - name: Publish to npm (OIDC trusted publishing, no token)
+        run: npm publish --ignore-scripts --access public --tag ${{ github.event.inputs.dist-tag || 'latest' }}

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "engines": {
     "node": ">= 16.0.0"
   },
-  "packageManager": "^yarn@1.22.15",
+  "packageManager": "yarn@1.22.22",
   "jest": {
     "preset": "react-native",
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
## What
- `release_package.yml`, ported from terra-react: publishes `react-native-terra-rt-react` to npm via **trusted publishing (OIDC)** — no stored token. Triggered by a GitHub Release, or workflow_dispatch (used by the new `bump-terra-rt-react` workflows in TerraRTAndroidPackage/TerraRTiOSPackage). The bob build runs explicitly because publish uses `--ignore-scripts` and this package has no `prepare` script.
- **Fixes the long-red CI**: `"packageManager": "^yarn@1.22.15"` is malformed (bad semver prefix) and the yarn 1.22.x on current runner images hard-refuses to run against it — every CI job has failed on this since at least Sep 2025. Corrected to `yarn@1.22.22`.

## Testing
`yarn install --frozen-lockfile` + `yarn prepack` verified locally after the fix (lib/commonjs, lib/module, lib/typescript built).

## Manual step before first publish
Add a **Trusted Publisher** on npmjs.com for `react-native-terra-rt-react`: org `tryterra`, repo `terra-rt-react`, workflow `release_package.yml` (mirror of terra-react's config).