### PR TITLE
Rename npm package to terra-rt (unscoped, org-team owned)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# react-native-terra-rt-react
+# terra-rt
 
 React Native bridge for Terra Realtime mobile SDKs
 
 ## Installation
 
 ```sh
-npm install react-native-terra-rt-react
+npm install terra-rt
 ```
 
 ## Usage

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -21,14 +21,14 @@ import {
   stopRealtime,
   disconnect,
   getUserId,
-} from 'react-native-terra-rt-react';
+} from 'terra-rt';
 import { config } from './config';
 import type {
   Device,
   SuccessMessage,
   Update,
-} from 'react-native-terra-rt-react';
-import { Connections, DataTypes } from 'react-native-terra-rt-react';
+} from 'terra-rt';
+import { Connections, DataTypes } from 'terra-rt';
 import { BLWidget } from './iOSBleWidget';
 
 export default function App() {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -23,11 +23,7 @@ import {
   getUserId,
 } from 'terra-rt';
 import { config } from './config';
-import type {
-  Device,
-  SuccessMessage,
-  Update,
-} from 'terra-rt';
+import type { Device, SuccessMessage, Update } from 'terra-rt';
 import { Connections, DataTypes } from 'terra-rt';
 import { BLWidget } from './iOSBleWidget';
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "react-native-terra-rt-react",
-  "version": "0.2.4",
-  "description": "test",
+  "name": "terra-rt",
+  "version": "0.2.5",
+  "description": "React Native SDK for Terra's realtime (websocket) streaming — live data from BLE devices and Apple Watch.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
   "types": "lib/typescript/index.d.ts",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ export * from './types';
 export * from './enums';
 
 const LINKING_ERROR =
-  `The package 'react-native-terra-rt-react' doesn't seem to be linked. Make sure: \n\n` +
+  `The package 'terra-rt' doesn't seem to be linked. Make sure: \n\n` +
   Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo Go\n';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "react-native-terra-rt-react": ["./src/index"]
+      "terra-rt": ["./src/index"]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,


### PR DESCRIPTION
Renames the cursedly-named `react-native-terra-rt-react` (redundant, individually owned by elliottyu) to **`terra-rt`**.

**Unscoped**, to match the org's other SDK packages — `terra-react`, `terra-api`, `terra-capacitor`, `terra-graphs`, `react-native-terra-apple` are all unscoped names managed by the `tryterra` npm org team (only `@tryterra/terra-ui` is scoped). After the first publish, `terra-rt` is added to the same org team for parity.

- package.json name → `terra-rt`, version 0.2.4 → 0.2.5 (continuity).
- example imports updated.
- Native module names (podspec `s.name`, android `com.terrartreact`) unchanged — RN autolinking is independent of the npm name, and the `bump-terra-rt-react` workflows reference the podspec by filename.
- `release_package.yml` publishes via npm OIDC trusted publishing (no token) once configured.

First version bootstrap-published manually; thereafter GitHub Releases publish via OIDC.