### PR TITLE
release: pin native SDKs to op=8 versions (terra-rt 0.2.6)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -71,7 +71,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation 'co.tryterra:terra-rtandroid:0.4.3'
+  implementation 'co.tryterra:terra-rtandroid:0.4.11'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-rt",
-  "version": "0.2.5",
-  "description": "React Native SDK for Terra's realtime (websocket) streaming — live data from BLE devices and Apple Watch.",
+  "version": "0.2.6",
+  "description": "React Native SDK for Terra's realtime (websocket) streaming \u2014 live data from BLE devices and Apple Watch.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
   "types": "lib/typescript/index.d.ts",

--- a/react-native-terra-rt-react.podspec
+++ b/react-native-terra-rt-react.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
   s.frameworks = ['HealthKit']
   s.dependency "React-Core"
-  s.dependency "TerraRTiOS", "=0.3.12"
+  s.dependency "TerraRTiOS", "=0.3.13"
 
 
   # Don't install the dependencies when we run `pod install` in the old architecture.


### PR DESCRIPTION
Pulls op=8 STATUS device-link (Bluetooth) reporting into the RN wrapper:
- `terra-rtandroid` 0.4.3 → **0.4.11** (live on Maven Central)
- `TerraRTiOS` =0.3.12 → **=0.3.13** (live on CocoaPods trunk)
- `terra-rt` 0.2.5 → **0.2.6**

Both native deps are already published, so this is safe to merge. **After merge, create a GitHub Release tagged `0.2.6`** → `release_package.yml` publishes `terra-rt@0.2.6` via npm OIDC (no token).

One combined bump (both platforms) instead of running the two per-platform bump workflows separately — a single `terra-rt` publish.