### PR TITLE
feat: scan stop, permission preflight, availability check, typed even…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -71,7 +71,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation 'co.tryterra:terra-rtandroid:0.4.12'
+  implementation 'co.tryterra:terra-rtandroid:0.4.13'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/com/terrartreact/TerraRtReactModule.java
+++ b/android/src/main/java/com/terrartreact/TerraRtReactModule.java
@@ -338,6 +338,28 @@ public class TerraRtReactModule extends ReactContextBaseJavaModule {
     this.terraRt.startDeviceScan(Objects.requireNonNull(this.parseConnection(connections)), this::_deviceHandler_);
   }
 
+  /** Stops a device scan started by startDeviceScanWithCallback. */
+  @ReactMethod
+  public void stopDeviceScan(String connections, Promise promise){
+    WritableMap map = new WritableNativeMap();
+    if (this.terraRt == null){
+      map.putBoolean("success", false);
+      map.putString("error", "Please initialise a terra class by using `initTerra` first");
+      promise.resolve(map);
+      return;
+    }
+    Connections connection = this.parseConnection(connections);
+    if (connection == null){
+      map.putBoolean("success", false);
+      map.putString("error", "Invalid Connection");
+      promise.resolve(map);
+      return;
+    }
+    this.terraRt.stopDeviceScan(connection);
+    map.putBoolean("success", true);
+    promise.resolve(map);
+  }
+
   @ReactMethod
   public void connectDevice(String deviceId, Promise promise){
     WritableMap map = new WritableNativeMap();

--- a/ios/TerraRtReact.m
+++ b/ios/TerraRtReact.m
@@ -36,6 +36,10 @@ RCT_EXTERN_METHOD(startBluetoothScan:(NSString *)connections
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(stopDeviceScan:(NSString *)connections
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(connectDevice:(NSString *)device
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/TerraRtReact.swift
+++ b/ios/TerraRtReact.swift
@@ -141,6 +141,21 @@ class TerraRtReact: NSObject {
         resolve(["success": true])
     }
 
+    @objc(stopDeviceScan:withResolver:withRejecter:)
+    func stopDeviceScan(connections: String, resolve: @escaping RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {
+        guard let terraRT = TerraRtReact.terraRt else{
+            resolve(["success": false, "error": "Please initialise a terra class by using `initTerra` first"])
+            return
+        }
+
+        guard let connection = TerraRtReact.parseConnections(connections) else{
+            resolve(["success": false, "error": "Invalid Connection"])
+            return
+        }
+        terraRT.stopBluetoothScan(type: connection)
+        resolve(["success": true])
+    }
+
     @objc(startBluetoothScan:withResolver:withRejecter:)
     func startBluetoothScan(connections: String, resolve: @escaping RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {
         guard let terraRT = TerraRtReact.terraRt else{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-rt",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "React Native SDK for Terra's realtime (websocket) streaming \u2014 live data from BLE devices and Apple Watch.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -7,18 +7,48 @@ NativeModules.TerraRtReact = {
   stopForegroundService: jest.fn(async () => ({ success: true, error: null })),
   isIgnoringBatteryOptimizations: jest.fn(async () => false),
   requestIgnoreBatteryOptimizations: jest.fn(async () => true),
+  stopDeviceScan: jest.fn(async () => ({ success: true, error: null })),
+  stopRealtime: jest.fn(async () => ({ success: true, error: null })),
 };
 
 // require, not import: imports hoist above the NativeModules assignment,
 // which would capture the linking-error proxy instead of the mock.
 const {
   isIgnoringBatteryOptimizations,
+  isTerraRtAvailable,
   requestIgnoreBatteryOptimizations,
   startForegroundService,
+  stopDeviceScan,
   stopForegroundService,
+  stopRealtime,
 } = require('../index');
 
 const native = NativeModules.TerraRtReact;
+
+describe('scan control + platform mapping', () => {
+  beforeEach(() => {
+    Platform.OS = 'android';
+    jest.clearAllMocks();
+  });
+
+  it('isTerraRtAvailable reflects native module presence', () => {
+    expect(isTerraRtAvailable()).toBe(true);
+  });
+
+  it('stopDeviceScan calls through with the connection', async () => {
+    await stopDeviceScan('BLE');
+    expect(native.stopDeviceScan).toHaveBeenCalledWith('BLE');
+  });
+
+  it("maps 'PHONE' to the platform's native connection name", async () => {
+    await stopRealtime('PHONE');
+    expect(native.stopRealtime).toHaveBeenCalledWith('ANDROID');
+
+    Platform.OS = 'ios';
+    await stopRealtime('PHONE');
+    expect(native.stopRealtime).toHaveBeenCalledWith('APPLE');
+  });
+});
 
 describe('background-streaming API (android)', () => {
   beforeEach(() => {

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,4 +1,9 @@
-import { NativeModules, Platform } from 'react-native';
+import {
+  DeviceEventEmitter,
+  NativeModules,
+  PermissionsAndroid,
+  Platform,
+} from 'react-native';
 
 // Must exist before src/index is imported, or the linking-error proxy trips.
 NativeModules.TerraRtReact = {
@@ -9,6 +14,10 @@ NativeModules.TerraRtReact = {
   requestIgnoreBatteryOptimizations: jest.fn(async () => true),
   stopDeviceScan: jest.fn(async () => ({ success: true, error: null })),
   stopRealtime: jest.fn(async () => ({ success: true, error: null })),
+  startDeviceScanWithCallback: jest.fn(async () => ({
+    success: true,
+    error: null,
+  })),
 };
 
 // require, not import: imports hoist above the NativeModules assignment,
@@ -16,7 +25,9 @@ NativeModules.TerraRtReact = {
 const {
   isIgnoringBatteryOptimizations,
   isTerraRtAvailable,
+  onUpdate,
   requestIgnoreBatteryOptimizations,
+  startDeviceScanWithCallback,
   startForegroundService,
   stopDeviceScan,
   stopForegroundService,
@@ -75,6 +86,55 @@ describe('background-streaming API (android)', () => {
     await expect(requestIgnoreBatteryOptimizations()).resolves.toBe(true);
     expect(native.isIgnoringBatteryOptimizations).toHaveBeenCalled();
     expect(native.requestIgnoreBatteryOptimizations).toHaveBeenCalled();
+  });
+});
+
+describe('android scan-permission gate', () => {
+  beforeEach(() => {
+    Platform.OS = 'android';
+    jest.clearAllMocks();
+  });
+
+  it('rejects loudly when permissions are denied', async () => {
+    jest.spyOn(PermissionsAndroid, 'requestMultiple').mockResolvedValueOnce({
+      'android.permission.BLUETOOTH_SCAN': 'denied',
+    } as any);
+    await expect(startDeviceScanWithCallback('BLE')).rejects.toThrow(
+      /permissions not granted/i
+    );
+    expect(native.startDeviceScanWithCallback).not.toHaveBeenCalled();
+  });
+
+  it('scans once permissions are granted, with the mapped connection', async () => {
+    jest.spyOn(PermissionsAndroid, 'requestMultiple').mockResolvedValueOnce({
+      'android.permission.BLUETOOTH_SCAN': 'granted',
+      'android.permission.BLUETOOTH_CONNECT': 'granted',
+    } as any);
+    await startDeviceScanWithCallback('PHONE');
+    expect(native.startDeviceScanWithCallback).toHaveBeenCalledWith('ANDROID');
+  });
+});
+
+describe('typed event streams', () => {
+  beforeEach(() => {
+    Platform.OS = 'android';
+  });
+
+  it('onUpdate delivers normalized payloads and unsubscribes cleanly', () => {
+    const updates: any[] = [];
+    const unsubscribe = onUpdate((u: any) => updates.push(u));
+
+    DeviceEventEmitter.emit('Update', { type: 'HEART_RATE', val: 62 });
+    DeviceEventEmitter.emit('Update', { type: 'ACCELERATION', d: [0, 0, 1] });
+
+    expect(updates).toEqual([
+      { type: 'HEART_RATE', ts: null, val: 62, d: null },
+      { type: 'ACCELERATION', ts: null, val: null, d: [0, 0, 1] },
+    ]);
+
+    unsubscribe();
+    DeviceEventEmitter.emit('Update', { type: 'HEART_RATE', val: 70 });
+    expect(updates).toHaveLength(2);
   });
 });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -180,8 +180,6 @@ export function disconnect(
 }
 
 /* ------------------------- Typed event streams ------------------------- */
-// iOS emits from dedicated native handler modules; Android emits on the
-// global RCTDeviceEventEmitter (no module argument). Same event names.
 
 function emitterFor(iosModule: any): NativeEventEmitter {
   return new NativeEventEmitter(Platform.OS === 'ios' ? iosModule : undefined);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,12 @@
-import { NativeModules, Platform } from 'react-native';
-import type { Device, GetUserId, SuccessMessage } from './types';
-import type { Connections, DataTypes } from './enums';
+import {
+  NativeEventEmitter,
+  NativeModules,
+  PermissionsAndroid,
+  Platform,
+} from 'react-native';
+import type { Device, GetUserId, SuccessMessage, Update } from './types';
+import { Connections } from './enums';
+import type { DataTypes } from './enums';
 
 export * from './types';
 export * from './enums';
@@ -21,6 +27,28 @@ const TerraRtReact = NativeModules.TerraRtReact
         },
       }
     );
+
+/**
+ * Whether the native module is present. False in Expo Go or any build
+ * without the native side — check this to degrade gracefully instead of
+ * catching the linking error.
+ */
+export function isTerraRtAvailable(): boolean {
+  return NativeModules.TerraRtReact != null;
+}
+
+/**
+ * 'PHONE' means the phone's own sensors; the native SDKs name it per
+ * platform (APPLE / ANDROID). All connection-taking functions accept it.
+ */
+export type ConnectionInput = Connections | 'PHONE';
+
+function toNativeConnection(connections: ConnectionInput): Connections {
+  if (connections === 'PHONE') {
+    return Platform.OS === 'ios' ? Connections.APPLE : Connections.ANDROID;
+  }
+  return connections;
+}
 
 export function initTerra(
   devId: String,
@@ -49,14 +77,78 @@ export function startDeviceScan(
   );
 }
 
-export function startDeviceScanWithCallback(
-  connections: Connections
-): Promise<SuccessMessage> {
-  if (Platform.OS === 'ios') {
-    return TerraRtReact.startBluetoothScan(connections);
-  } else {
-    return TerraRtReact.startDeviceScanWithCallback(connections);
+function scanPermissionList() {
+  const wanted =
+    Number(Platform.Version) >= 31
+      ? [
+          PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
+          PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
+        ]
+      : [PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION];
+  return wanted.filter((p): p is NonNullable<typeof p> => p != null);
+}
+
+/**
+ * ANDROID ONLY (resolves true on iOS). Requests the runtime permissions a
+ * BLE scan needs: BLUETOOTH_SCAN/CONNECT on Android 12+, fine location
+ * below. Without them Android scans "succeed" and silently find nothing.
+ */
+export async function requestScanPermissions(): Promise<boolean> {
+  if (Platform.OS !== 'android') {
+    return true;
   }
+  const results = await PermissionsAndroid.requestMultiple(
+    scanPermissionList()
+  );
+  return Object.values(results).every(
+    (r) => r === PermissionsAndroid.RESULTS.GRANTED
+  );
+}
+
+async function hasScanPermissions(): Promise<boolean> {
+  const checks = await Promise.all(
+    scanPermissionList().map((p) => PermissionsAndroid.check(p))
+  );
+  return checks.every(Boolean);
+}
+
+/**
+ * Starts a callback-driven device scan (devices arrive via onDeviceFound).
+ * On Android the required runtime permissions are requested first unless
+ * `requestPermissions` is false; missing permissions REJECT loudly instead
+ * of the native behavior of scanning successfully and finding nothing.
+ */
+export async function startDeviceScanWithCallback(
+  connections: ConnectionInput,
+  options: { requestPermissions?: boolean } = {}
+): Promise<SuccessMessage> {
+  const { requestPermissions = true } = options;
+  if (Platform.OS === 'android') {
+    const granted = requestPermissions
+      ? await requestScanPermissions()
+      : await hasScanPermissions();
+    if (!granted) {
+      throw new Error(
+        'Bluetooth scan permissions not granted — call requestScanPermissions() or enable Nearby devices for this app in Android Settings'
+      );
+    }
+  }
+  const connection = toNativeConnection(connections);
+  if (Platform.OS === 'ios') {
+    return TerraRtReact.startBluetoothScan(connection);
+  } else {
+    return TerraRtReact.startDeviceScanWithCallback(connection);
+  }
+}
+
+/**
+ * Stops a scan started by startDeviceScanWithCallback. Safe to call when
+ * nothing is scanning. Restarting a wedged scan is stop → start.
+ */
+export function stopDeviceScan(
+  connections: ConnectionInput
+): Promise<SuccessMessage> {
+  return TerraRtReact.stopDeviceScan(toNativeConnection(connections));
 }
 
 export function connectDevice(device: Device): Promise<SuccessMessage> {
@@ -64,21 +156,75 @@ export function connectDevice(device: Device): Promise<SuccessMessage> {
 }
 
 export function startRealtime(
-  connections: Connections,
+  connections: ConnectionInput,
   dataTypes: Array<DataTypes>,
   token: String | null = null
 ): Promise<SuccessMessage> {
-  return TerraRtReact.startRealtime(connections, dataTypes, token);
+  return TerraRtReact.startRealtime(
+    toNativeConnection(connections),
+    dataTypes,
+    token
+  );
 }
 
 export function stopRealtime(
-  connections: Connections
+  connections: ConnectionInput
 ): Promise<SuccessMessage> {
-  return TerraRtReact.stopRealtime(connections);
+  return TerraRtReact.stopRealtime(toNativeConnection(connections));
 }
 
-export function disconnect(connections: Connections): Promise<SuccessMessage> {
-  return TerraRtReact.disconnect(connections);
+export function disconnect(
+  connections: ConnectionInput
+): Promise<SuccessMessage> {
+  return TerraRtReact.disconnect(toNativeConnection(connections));
+}
+
+/* ------------------------- Typed event streams ------------------------- */
+// iOS emits from dedicated native handler modules; Android emits on the
+// global RCTDeviceEventEmitter (no module argument). Same event names.
+
+function emitterFor(iosModule: any): NativeEventEmitter {
+  return new NativeEventEmitter(Platform.OS === 'ios' ? iosModule : undefined);
+}
+
+/** Devices discovered by startDeviceScanWithCallback. Returns unsubscribe. */
+export function onDeviceFound(cb: (device: Device) => void): () => void {
+  const sub = emitterFor(NativeModules.DeviceHandler).addListener(
+    'Device',
+    (d: any) =>
+      cb({
+        id: d?.id != null ? String(d.id) : null,
+        name: d?.name != null ? String(d.name) : null,
+        type: d?.type != null ? String(d.type) : '',
+      })
+  );
+  return () => sub.remove();
+}
+
+/** Data points from the active stream. Returns unsubscribe. */
+export function onUpdate(cb: (update: Update) => void): () => void {
+  const sub = emitterFor(NativeModules.UpdateHandler).addListener(
+    'Update',
+    (u: any) =>
+      cb({
+        type: u?.type ?? null,
+        ts: u?.ts ?? null,
+        val: u?.val ?? null,
+        d: u?.d ?? null,
+      })
+  );
+  return () => sub.remove();
+}
+
+/** The SDK's websocket-to-Terra connection state. Returns unsubscribe. */
+export function onConnectionUpdate(
+  cb: (connected: boolean) => void
+): () => void {
+  const sub = emitterFor(NativeModules.ConnectionHandler).addListener(
+    'ConnectionUpdate',
+    (connected: any) => cb(!!connected)
+  );
+  return () => sub.remove();
 }
 
 export function connectWithWatchOS(): Promise<SuccessMessage> {


### PR DESCRIPTION
## feat: scan control, permission preflight, typed events, PHONE connection

DX release closing the gaps that forced consuming apps to build their own layer on top of terra-rt. Pins **terra-rtandroid 0.4.13** (adds the native `stopDeviceScan` — merge/publish that first), TerraRTiOS stays 0.3.14. Wrapper version → **0.2.8**.

### New API

```ts
stopDeviceScan(connections)
requestScanPermissions(): Promise<boolean>
onDeviceFound(cb): () => void
onUpdate(cb): () => void
onConnectionUpdate(cb): () => void
```

### Behavior improvements

- **Scan stop** — `startDeviceScanWithCallback` had no inverse; BLE scans that wedge (common on some Android stacks) could only be recovered by switching connection types and back. Bridged to the SDK's `stopBluetoothScan` on iOS and the new `stopDeviceScan` on Android. Restarting a wedged scan is now stop → start.
- **Permission preflight** — on Android, `startDeviceScanWithCallback` now requests the required runtime permissions first (`BLUETOOTH_SCAN`/`CONNECT` on 12+, fine location below) and **rejects loudly** when missing, instead of the native behavior of scanning "successfully" and silently finding nothing — the single most common first-integration footgun. Opt out with `{ requestPermissions: false }` (still checks, still rejects loudly) for apps that run their own permission UX.
- **`'PHONE'` connection** — all connection-taking functions accept a platform-neutral `'PHONE'` for the phone's own sensors, mapped to `APPLE`/`ANDROID` internally; callers no longer branch on `Platform.OS`.
- **Typed events** — consumers previously had to construct `NativeEventEmitter`s against the wrapper's internal handler modules and handle the iOS-modules-vs-Android-global-emitter split themselves. Now exported, typed, normalized (missing fields → `null`), with unsubscribe functions.

### Tests

Suite grown to 9: scan-stop passthrough, permission gate (denied → loud rejection without touching native; granted → scan proceeds with the mapped connection), `PHONE` mapping on both platforms, event payload normalization + unsubscribe, plus the existing background-streaming coverage.

### Consumer impact

Fully backwards compatible — all additions; no signatures changed. The Terra Grip demo app's SDK adapter shrinks from ~200 lines to ~40 on adoption — the point of the release: apps shouldn't need an adapter layer to use the wrapper safely.